### PR TITLE
Use an X-macro for the list of patterns.

### DIFF
--- a/include/common_led.h
+++ b/include/common_led.h
@@ -54,3 +54,22 @@ class Wolfram135: public PatternRenderer {
       ~Wolfram135();
       void render(CRGB* leds) override;
 };
+
+/*
+ * List of all patterns, in the form of a parametric macro. Whenever
+ * you want to list all the known patterns in other parts of the code,
+ * you can invoke this with another macro name, and it will evaluate
+ * that macro with each pattern as an argument.
+ *
+ * The second parameter SEPARATOR will be interleaved between the
+ * invocations of the macro X.
+ */
+#define ALL_PATTERNS(X, SEPARATOR)                        \
+X(LedRace) SEPARATOR \
+X(TestPattern) SEPARATOR \
+X(Rainbow) SEPARATOR \
+X(Snowflakes1) SEPARATOR \
+X(Snowflakes2) SEPARATOR \
+X(TestPattern2) SEPARATOR \
+X(Twinkles) SEPARATOR \
+X(Wolfram135)

--- a/simulation/simulation.cpp
+++ b/simulation/simulation.cpp
@@ -1,22 +1,30 @@
+#include <string>
 #include <crgb.h>
 #include "simulation.h"
 #include "common_led.h"
 
-LedRace ledRace;
-TestPattern testPattern;
-Rainbow rainbow;
-Snowflakes1 snowflakes1;
-Snowflakes2 snowflakes2;
-TestPattern2 testPattern2;
-Twinkles twinkles;
-Wolfram135 wolfram135;
+// Define an instance of each pattern class
+#define MAKE_INSTANCE(classname) classname instance_of_##classname
+ALL_PATTERNS(MAKE_INSTANCE, ;);
+#undef MAKE_INSTANCE
 
+PatternRenderer* patternRenderer;
+
+extern "C" bool setup(const char *name_asciz) {
+  std::string name = name_asciz;
+
+  // Translate each pattern name as a string into the instance of the class
+#define CHECK_STRING(classname)                         \
+  if (name == #classname) {                             \
+    patternRenderer = &instance_of_##classname;         \
+    return true;                                        \
+  }
+  ALL_PATTERNS(CHECK_STRING, else)
+#undef CHECK_STRING
+
+  return false;
+}
 
 extern "C" void render(CRGB* leds) {
-
-  PatternRenderer* patternRenderer; 
-
-  patternRenderer = &testPattern;
-
   patternRenderer->render(leds);
 }

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -10,10 +10,18 @@ parser.add_argument("--library", default="./simulation.so",
                     help="Path to the simulation.so library to load")
 parser.add_argument("--led-size", type=int, default=4,
                     help="Size of an LED in the simulation")
+parser.add_argument("pattern", nargs="?", default="Snowflakes2",
+                    help="Name of the pattern class to run")
 args = parser.parse_args()
 
 # Load the compiled C library
 target = ctypes.CDLL(args.library)
+
+target.setup.argtypes = [ctypes.c_char_p]
+target.setup.restype = ctypes.c_bool
+pattern_buffer = ctypes.create_string_buffer(args.pattern.encode())
+if not target.setup(pattern_buffer):
+    sys.exit(f"Unrecognised pattern '{args.pattern}'")
 
 # Constants
 LEDS_SIDE = 132

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,29 +18,25 @@ CRGB leds[NUM_LEDS];
 ulong lastUpdateMicros;
 ulong lastSerialUpdateMicros;
 
-LedRace ledRace;
-TestPattern testPattern;
-TestPattern2 testPattern2;
-Rainbow rainbow;
-Snowflakes2 snowflake2;
-Twinkles twinkles;
-Wolfram135 wolfram135;
+// Define an instance of each pattern class
+#define MAKE_INSTANCE(classname) classname instance_of_##classname
+ALL_PATTERNS(MAKE_INSTANCE, ;);
+#undef MAKE_INSTANCE
 
 PatternRenderer* activePatternRenderer;
 
 void onOptionChange(std::string option) {
-  if (option.find("Snowflakes2") != std::string::npos) {
-    activePatternRenderer = &snowflake2;
-  } else if (option.find("Rainbow") != std::string::npos) {
-    activePatternRenderer = &rainbow;
-  } else if (option.find("Twinkles") != std::string::npos) {
-    activePatternRenderer = &twinkles;
-  } else if (option.find("Wolfram135") != std::string::npos) {
-    activePatternRenderer = &twinkles;
-  } else {
-    Serial.println("Unknown pattern");
-    activePatternRenderer = &ledRace;
+  // Translate each pattern name as a string into the instance of the class
+
+#define CHECK_STRING(classname)                         \
+  if (option.find(#classname) != std::string::npos) {   \
+    activePatternRenderer = &instance_of_##classname;   \
+    return;                                             \
   }
+  ALL_PATTERNS(CHECK_STRING, else)
+#undef CHECK_STRING
+
+  Serial.println("Unknown pattern");
 }
 
 void setup() {

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -1,4 +1,5 @@
 #include "secrets.h"
+#include "common_led.h"
 #include <arduino.h>
 #include <WiFi.h>
 #include <AsyncMqttClient.h>
@@ -15,7 +16,11 @@ const char * configuration_payload = R"END(
   "name": "Porch Lights Mode",
   "command_topic": "homeassistant/select/porch_lights_mode/set",
   "state_topic": "homeassistant/select/porch_lights_mode/state",
-  "options": ["Snowflakes2", "Rainbow", "Twinkles", "Wolfram135"],
+  "options": [)END"
+#define QUOTE_PATTERN(classname) "\"" #classname "\""
+ALL_PATTERNS(QUOTE_PATTERN, ", ")
+#undef QUOTE_PATTERN
+R"END(],
   "unique_id": "porch_lights_mode",
   "device": {
     "identifiers": ["porch_lights_001"],


### PR DESCRIPTION
The list of pattern names is now defined just once, in common_led.h, in the form of a macro that takes another macro as a parameter. So you can iterate over the list of pattern names doing a thing for each one, basically by defining a macro to do your thing, and invoking ALL_PATTERNS(that-macro).

This allows autogenerating a list of instances of all the classes, and a list of if statements that checks a string against all the class names, and even the list of available pattern names in the hardcoded JSON in mqtt.cpp. But for the last of those, I had to also give ALL_PATTERNS a second argument to interleave between the invocations of the parameter macro, because otherwise, you wouldn't be able to avoid having a trailing comma at the end of the JSON list, which isn't legal JSON.